### PR TITLE
fixed typo in docker image name

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,12 @@ To run it in participant level mode (for one participant):
 
     docker run -i --rm \
 		-v /Users/filo/data/ds005:/bids_dataset \
-		cbinyu/pydeface \
+		cbinyu/bids_pydeface \
 		/bids_dataset /bids_dataset participant --participant_label 01
 
 To run it for a specific modality of images:
 
     docker run -i --rm \
                 -v /Users/filo/data/ds005:/bids_dataset \
-		cbinyu/pydeface \
+		cbinyu/bids_pydeface \
 		/bids_dataset /bids_dataset participant --participant_label 01 --modalities T1w
-


### PR DESCRIPTION
Typo in docker image name corrected. Same typo exist on dockerhub page https://hub.docker.com/r/cbinyu/bids_pydeface.